### PR TITLE
Use 'file' attrs to check if object is local or not

### DIFF
--- a/server/lib/handlers/common.py
+++ b/server/lib/handlers/common.py
@@ -7,7 +7,7 @@ class UrlTransferHandler(TransferHandler):
     def __init__(self, url, transferId, itemId, psPath):
         TransferHandler.__init__(self, transferId, itemId, psPath)
         self.url = url
-        self.flen = self.item['meta']['size']
+        self.flen = self._getFileFromItem()['size']
 
     def mkdirs(self):
         try:

--- a/server/lib/tm_utils.py
+++ b/server/lib/tm_utils.py
@@ -24,6 +24,13 @@ class TransferHandler:
         self.item = Models.itemModel.load(self.itemId, force=True)
         self.lastTransferred = 0
 
+    def _getFileFromItem(self):
+        files = list(Models.itemModel.childFiles(item=self.item))
+        if len(files) != 1:
+            raise Exception('Wrong number of files for item ' + str(self.item['_id']) +
+                            ': ' + str(len(files)))
+        return Models.fileModel.load(files[0]['_id'], force=True)
+
     def run(self):
         try:
             Models.transferModel.setStatus(self.transferId,


### PR DESCRIPTION
Long story short: `phys_path` is something I introduced a long time ago in the original ytHub plugin. It's no longer being used, i.e. new files that are imported do not have that attribute. Additionally it's possible to detect whether a file/item is a url by checking for `linkUrl` attribute. 

For some reason `test02HttpFile (plugin_tests.wt_data_manager_test.IntegrationTestCase)` fails for me locally (even before those changes) so I can't verify if haven't messed anything up.  When I have more time I'll try to figure out the reason, here's the traceback anyway:

```
8: ======================================================================
8: FAIL: test02HttpFile (plugin_tests.wt_data_manager_test.IntegrationTestCase)
8: ----------------------------------------------------------------------
8: Traceback (most recent call last):
8:   File "/home/xarth/codes/girder/plugins/wt_data_manager/plugin_tests/wt_data_manager_test.py", line 77, in test02HttpFile
8:     self._testItem(dataSet, self.httpItem)
8:   File "/home/xarth/codes/girder/plugins/wt_data_manager/plugin_tests/wt_data_manager_test.py", line 105, in _testItem
8:     self._testItemWithSession(session, item, download=download, transferCount=transferCount)
8:   File "/home/xarth/codes/girder/plugins/wt_data_manager/plugin_tests/wt_data_manager_test.py", line 132, in _testItemWithSession
8:     self.assertEqual(os.path.getsize(psPath), item['size'])
8: AssertionError: 0 != 1048576
8: 
8: ----------------------------------------------------------------------
```