### PR TITLE
Support GridFS assetstore

### DIFF
--- a/server/lib/transfer_manager.py
+++ b/server/lib/transfer_manager.py
@@ -145,7 +145,7 @@ class SimpleTransferManager(TransferManager):
                     ModelImporter.model('assetstore').load(file['assetstoreId'])
                 adapter = assetstore_utilities.getAssetstoreAdapter(store)
                 url = adapter.fullPath(file)
-            except ValidationException:
+            except (AttributeError, ValidationException):
                 pass
         if url:
             try:

--- a/server/models/transfer.py
+++ b/server/models/transfer.py
@@ -1,5 +1,6 @@
 from girder.models.model_base import AccessControlledModel
 from girder.utility.model_importer import ModelImporter
+from girder.utility import path as path_util
 from girder.constants import AccessType
 from ..constants import TransferStatus
 from bson import objectid
@@ -48,11 +49,7 @@ class Transfer(AccessControlledModel):
 
     def getPathFromRoot(self, user, itemId):
         item = self.itemModel.load(itemId, user=user, level=AccessType.READ)
-        dictPath = self.itemModel.parentsToRoot(item, user=user)
-        pathFromRoot = '/'
-        for dict in dictPath:
-            pathFromRoot = pathFromRoot + '/' + dict['object']['name']
-        return pathFromRoot
+        return path_util.getResourcePath('item', item, user=user)
 
     def setStatus(self, transferId, status, error=None, size=0, transferred=0,
                   setTransferStartTime=False, setTransferEndTime=False):

--- a/server/resources/fs.py
+++ b/server/resources/fs.py
@@ -74,7 +74,7 @@ class FS(Resource):
                             self.model('assetstore').load(fileitem['assetstoreId'])
                         adapter = assetstore_utilities.getAssetstoreAdapter(store)
                         fileitem["path"] = adapter.fullPath(fileitem)
-                    except ValidationException:
+                    except (ValidationException, AttributeError):
                         pass
                 files.append(item)
             else:
@@ -90,10 +90,13 @@ class FS(Resource):
         for fileitem in self.model('item').childFiles(item):
             if 'imported' not in fileitem and \
                             fileitem.get('assetstoreId') is not None:
-                store = \
-                    self.model('assetstore').load(fileitem['assetstoreId'])
-                adapter = assetstore_utilities.getAssetstoreAdapter(store)
-                fileitem["path"] = adapter.fullPath(fileitem)
+                try:
+                    store = \
+                        self.model('assetstore').load(fileitem['assetstoreId'])
+                    adapter = assetstore_utilities.getAssetstoreAdapter(store)
+                    fileitem["path"] = adapter.fullPath(fileitem)
+                except (ValidationException, AttributeError):
+                    pass
             files.append(fileitem)
         return {'folders': [], 'files': files}
 


### PR DESCRIPTION
GridFS (which for convenience is a default assetstore in dev deployment) doesn't have the `fullPath` method. I added catching `AttributeError` to take that into account.

Second commit allows *wthomedir* to work with data in User's folders. User model doesn't have a 'name' attribute which raised 'KeyError' when `Transfer.getPathFromRoot` tried to build path for `/user/kowalikk/Home`.