### PR TITLE
Add a helper method for creating dataSet out of folder recursively

### DIFF
--- a/plugin_tests/wt_data_manager_test.py
+++ b/plugin_tests/wt_data_manager_test.py
@@ -231,7 +231,6 @@ class IntegrationTestCase(base.TestCase):
         # test get lock
         resp = self.request('/dm/lock/%s' % lockId, method='GET', user=self.user)
         self.assertStatusOk(resp)
-            self.cache[obj_id] = self.girder_cli.get('dm/fs/%s/listing' % obj_id2
         self.assertEqual(lockId, str(resp.json['_id']))
 
         item = self.reloadItemRest(item)

--- a/plugin_tests/wt_data_manager_test.py
+++ b/plugin_tests/wt_data_manager_test.py
@@ -192,7 +192,7 @@ class IntegrationTestCase(base.TestCase):
 
         # get session
         resp = self.request('/dm/session/%s' % sessionId, method='GET', user=self.user, params={
-            'loadObjects': 'true'
+            'loadObjects': True
         })
         self.assertStatusOk(resp)
         self.assertEqual(sessionId, str(resp.json['_id']))
@@ -231,6 +231,7 @@ class IntegrationTestCase(base.TestCase):
         # test get lock
         resp = self.request('/dm/lock/%s' % lockId, method='GET', user=self.user)
         self.assertStatusOk(resp)
+            self.cache[obj_id] = self.girder_cli.get('dm/fs/%s/listing' % obj_id2
         self.assertEqual(lockId, str(resp.json['_id']))
 
         item = self.reloadItemRest(item)

--- a/plugin_tests/wt_data_manager_test.py
+++ b/plugin_tests/wt_data_manager_test.py
@@ -7,6 +7,7 @@ import time
 import os
 import cherrypy
 import json
+from operator import itemgetter
 from .httpserver import Server
 # oh, boy; you'd think we've learned from #include...
 # from plugins.wt_data_manager.server.constants import PluginSettings
@@ -306,6 +307,15 @@ class IntegrationTestCase(base.TestCase):
         self.assertEqual(1, remainingCount)
         self.assertEqual(1, len(self._getCachedItems()))
         gc.resume()
+
+    def test08Misc(self):
+        resp = self.request('/dm/folder/{_id}'.format(**self.testFolder),
+                            method='GET', user=self.user)
+        self.assertStatusOk(resp)
+        self.assertEqual(
+            sorted(resp.json, key=itemgetter('itemId')),
+            sorted(self.makeDataSet(self.gfiles, objectids=False),
+                   key=itemgetter('itemId')))
 
     def _getCachedItems(self):
         return list(self.model('item').find({'dm.cached': True}, user=self.user))

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -7,6 +7,7 @@ from .resources.lock import Lock
 from .resources.transfer import Transfer
 from .resources.dm import DM
 from .resources.fs import FS
+from .resources.misc import folderToDataset
 from girder.models.setting import Setting
 from girder.utility import setting_utilities
 from girder.constants import SettingDefault, AccessType
@@ -90,6 +91,8 @@ def load(info):
     info['apiRoot'].dm.route('PUT', ('fs', ':id', 'setProperties'), fs.setProperties)
     info['apiRoot'].dm.route('GET', ('fs', ':id', 'listing'), fs.getListing)
     info['apiRoot'].dm.route('GET', ('fs', ':id', 'evict'), lock.evict)
+
+    info['apiRoot'].dm.route('GET', ('folder', ':id'), folderToDataset)
 
     def itemLocked(event):
         dict = event.info

--- a/server/lib/file_gc.py
+++ b/server/lib/file_gc.py
@@ -199,5 +199,5 @@ class LRUSortingScheme(CollectionSortingScheme):
         if Lock.FIELD_LAST_UNLOCKED in item:
             return item[Lock.FIELD_LAST_UNLOCKED]
         else:
-            logger.warn('Item %s does not have a dm.lastUnlocked field.' % item['_id'])
+            logger.warning('Item %s does not have a dm.lastUnlocked field.' % item['_id'])
             return BEGINNING_OF_TIME

--- a/server/lib/handler_factory.py
+++ b/server/lib/handler_factory.py
@@ -12,6 +12,7 @@ class HandlerFactory:
         self.handlers = {}
         self.handlers['local'] = Local
         self.handlers['http'] = Http
+        self.handlers['https'] = Http
         self.handlers['file'] = Local
         self.handlers['globus'] = Globus
 

--- a/server/lib/transfer_manager.py
+++ b/server/lib/transfer_manager.py
@@ -104,7 +104,7 @@ class TransferManager:
                 self.startTransfer(user, item['itemId'], item['sessionId'])
             except Exception as ex:
                 logger.warning('Failed to strart transfer for itemId %s. Reason: %s'
-                               % (item['itemId'], ex.message))
+                               % (item['itemId'], str(ex)))
 
     def getUser(self, userId):
         return Models.userModel.load(userId, force=True)

--- a/server/models/session.py
+++ b/server/models/session.py
@@ -47,7 +47,7 @@ class Session(AccessControlledModel):
         :param user: The user creating the job.
         :type user: dict or None
         :param dataSet: The initial dataSet associated with this session. The dataSet is a list
-         of dictionaries with two keys: 'itemId', and 'mountPath'
+         of dictionaries with two keys: 'itemId', and 'mountPoint'
         :type dataSet: list
         """
 
@@ -143,7 +143,7 @@ class Session(AccessControlledModel):
 
     def findRootContainer(self, session, path):
         for obj in session['dataSet']:
-            rootPath = obj['mountPath']
+            rootPath = obj['mountPoint']
             if path == rootPath:
                 return (None, self.loadObject(str(obj['itemId'])))
             if rootPath[-1] != '/':

--- a/server/models/session.py
+++ b/server/models/session.py
@@ -18,6 +18,7 @@ class Session(AccessControlledModel):
         self.folderModel = ModelImporter.model('folder')
         self.itemModel = ModelImporter.model('item')
         self.lockModel = ModelImporter.model('lock', 'wt_data_manager')
+        self.objFields = ['_id', 'created', 'name', 'size', 'updated']
 
     def validate(self, session):
         return session
@@ -68,13 +69,13 @@ class Session(AccessControlledModel):
         for entry in dataSet:
             if 'type' in entry:
                 continue
-            folder = self.folderModel.load(entry['itemId'], force=True)
+            folder = self.folderModel.load(entry['itemId'], force=True, fields=self.objFields)
             if folder is not None:
                 entry['type'] = 'folder'
                 entry['obj'] = folder
             else:
                 entry['type'] = 'item'
-                entry['obj'] = self.itemModel.load(entry['itemId'], force=True)
+                entry['obj'] = self.itemModel.load(entry['itemId'], force=True, fields=self.objFields)
 
     def checkOwnership(self, user, session):
         if 'ownerId' in session:

--- a/server/models/session.py
+++ b/server/models/session.py
@@ -75,7 +75,8 @@ class Session(AccessControlledModel):
                 entry['obj'] = folder
             else:
                 entry['type'] = 'item'
-                entry['obj'] = self.itemModel.load(entry['itemId'], force=True, fields=self.objFields)
+                entry['obj'] = self.itemModel.load(entry['itemId'], force=True,
+                                                   fields=self.objFields)
 
     def checkOwnership(self, user, session):
         if 'ownerId' in session:

--- a/server/resources/misc.py
+++ b/server/resources/misc.py
@@ -29,6 +29,10 @@ def folderToDataset(self, folder):
             })
         for child_folder in FolderModel().childFolders(
                 parentType='folder', parent=folder, user=user):
+            data_set.append({
+                'itemId': str(child_folder['_id']),
+                'mountPoint': os.path.join(current_path, child_folder['name'])
+            })
             data_set += _recurse(
                 child_folder,
                 os.path.join(current_path, child_folder['name']),

--- a/server/resources/misc.py
+++ b/server/resources/misc.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+
+from girder.api import access
+from girder.api.describe import Description, autoDescribeRoute
+from girder.api.rest import boundHandler
+from girder.constants import AccessType, TokenScope
+from girder.models.folder import Folder as FolderModel
+
+
+@access.public(scope=TokenScope.DATA_READ)
+@autoDescribeRoute(
+    Description('Convert folder to dataSet')
+    .responseClass('DataSet')
+    .modelParam('id', 'The ID of the folder.', model=FolderModel, level=AccessType.READ)
+    .errorResponse('ID was invalid.')
+    .errorResponse('Read access was denied for the folder.', 403)
+)
+@boundHandler()
+def folderToDataset(self, folder):
+    def _recurse(folder, current_path, user):
+        data_set = []
+        for item in FolderModel().childItems(folder=folder):
+            data_set.append({
+                'itemId': str(item['_id']),
+                'mountPoint': os.path.join(current_path, item['name'])
+            })
+        for child_folder in FolderModel().childFolders(
+                parentType='folder', parent=folder, user=user):
+            data_set += _recurse(
+                child_folder,
+                os.path.join(current_path, child_folder['name']),
+                user
+            )
+        return data_set
+
+    return _recurse(folder, '/', self.getCurrentUser())

--- a/server/resources/session.py
+++ b/server/resources/session.py
@@ -3,7 +3,7 @@
 
 
 from girder.api.rest import Resource, RestException
-from girder.api.rest import filtermodel, loadmodel
+from girder.api.rest import filtermodel
 from girder.constants import AccessType
 from girder.api import access
 from girder.api.describe import Description, describeRoute, autoDescribeRoute


### PR DESCRIPTION
Since we currently keep data structure for Tales in a dedicated folder, it made sense to make it easy to convert that root folder into dataset. Once we have UI components that will make full use of DMS we could make it deprecated.

Additionally this PR sneaks in some bugfixes:
 * more py3 fixes
 * restrict item/folder fields that are passed to dataSet in order to significantly reduce its size (it was important on the fuse end)
 * `mountPath` -> `mountPoint` was omitted in some places
 * some endpoints were meant to have optional arguments, which weren't really optional. I fixed that by updating girder decorators we use. I only did that for `/dm/session`, there might be other places that need that too.
