### PR TITLE
Validate dataSet using schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,8 +171,8 @@ DM.createSession(user, dataSet)
 ```
 
 where ``dataSet`` is a list of dictionaries with keys ``itemId`` and
-``mountPoint``, where ``itemId`` is a Girder item or folder id and
-``mountPoint`` is an absolute path where the item/folder are mounted in the
+``mountPath``, where ``itemId`` is a Girder item or folder id and
+``mountPath`` is an absolute path where the item/folder are mounted in the
 EFS.
 
 ```python
@@ -187,8 +187,8 @@ Example:
 dm = info['apiRoot'].dm
 
 dataSet = [
-    {'itemId': '58b08d98cbb11e6d0f95df9f', 'mountPoint': '/x/y/z'},
-    {'itemId': '582f621ccbb11e75430a89ae', 'mountPoint': '/myfile.dat'}
+    {'itemId': '58b08d98cbb11e6d0f95df9f', 'mountPath': '/x/y/z'},
+    {'itemId': '582f621ccbb11e75430a89ae', 'mountPath': '/myfile.dat'}
 ]
 
 session = dm.createSession(user, dataSet)

--- a/plugin_tests/wt_data_manager_test.py
+++ b/plugin_tests/wt_data_manager_test.py
@@ -74,9 +74,9 @@ class IntegrationTestCase(base.TestCase):
 
     def makeDataSet(self, items, objectids=True):
         if objectids:
-            return [{'itemId': f['_id'], 'mountPoint': '/' + f['name']} for f in items]
+            return [{'itemId': f['_id'], 'mountPath': '/' + f['name']} for f in items]
         else:
-            return [{'itemId': str(f['_id']), 'mountPoint': '/' + f['name']} for f in items]
+            return [{'itemId': str(f['_id']), 'mountPath': '/' + f['name']} for f in items]
 
     def test01LocalFile(self):
         dataSet = self.makeDataSet(self.gfiles)

--- a/server/lib/transfer_manager.py
+++ b/server/lib/transfer_manager.py
@@ -104,7 +104,7 @@ class TransferManager:
                 self.startTransfer(user, item['itemId'], item['sessionId'])
             except Exception as ex:
                 logger.warning('Failed to strart transfer for itemId %s. Reason: %s'
-                               % (item['itemId'], ex.message))
+                               % (item['itemId'], str(ex)))
 
     def getUser(self, userId):
         return Models.userModel.load(userId, force=True)

--- a/server/resources/session.py
+++ b/server/resources/session.py
@@ -3,11 +3,12 @@
 
 
 from girder.api.rest import Resource, RestException
-from girder.api.rest import filtermodel, loadmodel
+from girder.api.rest import filtermodel
 from girder.constants import AccessType
 from girder.api import access
-from girder.api.describe import Description, describeRoute
-import json
+from girder.api.describe import Description, autoDescribeRoute
+from ..models.session import Session as SessionModel
+from ..schema.dataset import dataSetSchema
 
 
 class Session(Resource):
@@ -19,74 +20,70 @@ class Session(Resource):
         return session
 
     @access.user
-    @filtermodel(model='session', plugin='wt_data_manager')
-    @describeRoute(
+    @filtermodel(model=SessionModel)
+    @autoDescribeRoute(
         Description('List sessions for a given user.')
     )
-    def listSessions(self, params):
+    def listSessions(self):
         user = self.getCurrentUser()
-        return list(self.model('session', 'wt_data_manager').list(user=user))
+        return list(SessionModel().list(user=user))
 
     @access.user
-    @loadmodel(model='session', plugin='wt_data_manager', level=AccessType.READ)
-    @describeRoute(
+    @filtermodel(model=SessionModel)
+    @autoDescribeRoute(
         Description('Get a session by ID.')
-        .param('id', 'The ID of the session.', paramType='path')
-        .param('loadObjects', 'If specified, the dataSet of the returned session will contain'
+        .modelParam('id', 'The ID of the session.', model=SessionModel, level=AccessType.READ)
+        .param('loadObjects', 'If True, the dataSet of the returned session will contain'
                               'two additional fields for each entry: "type": "folder"|"item" '
-                              'and "obj": <itemOrFolder>', paramType='query')
+                              'and "obj": <itemOrFolder>', dataType='boolean', required=False,
+                              default=False)
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the session.', 403)
     )
-    @filtermodel(model='session', plugin='wt_data_manager')
-    def getSession(self, session, params):
-        if 'loadObjects' in params:
-            self.model('session', 'wt_data_manager').loadObjects(session['dataSet'])
+    def getSession(self, session, loadObjects):
+        if loadObjects:
+            SessionModel().loadObjects(session['dataSet'])
         return session
 
     @access.user
-    @loadmodel(model='session', plugin='wt_data_manager', level=AccessType.WRITE)
-    @describeRoute(
+    @autoDescribeRoute(
         Description('Removes an existing session.')
-        .param('id', 'The ID of the session.', paramType='path')
+        .modelParam('id', 'The ID of the session.', model=SessionModel, level=AccessType.WRITE)
         .errorResponse('ID was invalid.')
         .errorResponse('Access was denied for the session.', 403)
     )
-    def removeSession(self, session, params):
+    def removeSession(self, session):
         user = self.getCurrentUser()
-        return self.model('session', 'wt_data_manager').deleteSession(user, session)
+        return SessionModel().deleteSession(user, session)
 
     @access.user
-    @describeRoute(
+    @autoDescribeRoute(
         Description('Creates a session.')
-        .param('dataSet', 'An optional data set to initialize the session with. '
-               'A data set is a list of objects of the form '
-               '{"itemId": string, "mountPath": string}.', paramType='query')
+        .jsonParam(
+            'dataSet', 'An optional data set to initialize the session with. '
+            'A data set is a list of objects of the form '
+            '{"itemId": string, "mountPath": string}.', paramType='query', schema=dataSetSchema)
     )
-    def createSession(self, params):
+    def createSession(self, dataSet):
         user = self.getCurrentUser()
-        dataSet = json.loads(params.get('dataSet', '[]'))
-        return self.model('session', 'wt_data_manager').createSession(user, dataSet)
+        return SessionModel().createSession(user, dataSet)
 
     @access.user
-    @describeRoute(
+    @autoDescribeRoute(
         Description('Get an object in a session using a path.')
-        .param('id', 'The ID of the session.', paramType='path')
+        .modelParam('id', 'The ID of the session.', model=SessionModel, level=AccessType.READ)
         .param('path', 'The path of the object, starting from the mount point.',
                paramType='query')
         .param('children', 'Whether to also return a listing of all the children '
-               'of the object at the specified path', paramType='query')
+               'of the object at the specified path', dataType='boolean', required=False,
+               default=False)
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the session.', 403)
         .errorResponse('Object was not found.', 401)
     )
-    def getObject(self, session, params):
+    def getObject(self, session, path, children):
         user = self.getCurrentUser()
-        children = False
-        if 'children' in params:
-            children = True
         try:
-            return self.model('session', 'wt_data_manager').getObject(user, session,
-                                                                      params['path'], children)
+            return SessionModel().getObject(user, session, path, children)
         except LookupError as ex:
-            raise RestException(ex.message, code=401)
+            raise RestException(str(ex), code=401)

--- a/server/rest.py
+++ b/server/rest.py
@@ -1,2 +1,0 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-

--- a/server/schema/dataset.py
+++ b/server/schema/dataset.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from girder.api.docs import addModel
+
+
+dataSetItemSchema = {
+    'title': 'dataSetItem',
+    '$schema': 'http://json-schema.org/draft-04/schema#',
+    'description': 'A schema representing data elements used in DMS dataSets',
+    'type': 'object',
+    'properties': {
+        'itemId': {
+            'type': 'string',
+            'description': 'ID of a Girder item or a Girder folder'
+        },
+        'mountPath': {
+            'type': 'string',
+            'description': 'An absolute path where the item/folder are mounted in the EFS'
+        }
+    },
+    'required': ['itemId', 'mountPath']
+}
+
+dataSetSchema = {
+    'title': 'A list of resources with a corresponding mount points in the ESF',
+    '$schema': 'http://json-schema.org/draft-04/schema#',
+    'type': 'array',
+    'items': dataSetItemSchema,
+}
+
+addModel('dataSet', dataSetSchema)


### PR DESCRIPTION
This PR ensures that we're consistently using `mountPath` (instead of `mountPoint`) throughout both code and docs. We now validate that `dataSet` passed to `POST /session` is following the predefined schema/