### PR TITLE
Allow to create a Session from Tale's involatileData

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -4,3 +4,4 @@ version: 0.6.0dev0
 dependencies:
     - oauth
     - globus_handler
+    - wholetale

--- a/plugin_tests/wt_data_manager_test.py
+++ b/plugin_tests/wt_data_manager_test.py
@@ -7,6 +7,7 @@ import time
 import os
 import cherrypy
 import json
+import shutil
 from .httpserver import Server
 # oh, boy; you'd think we've learned from #include...
 # from plugins.wt_data_manager.server.constants import PluginSettings
@@ -28,9 +29,13 @@ class IntegrationTestCase(base.TestCase):
     def setUp(self):
         base.TestCase.setUp(self)
 
-        self.user = self.model('user').createUser('wt-dm-test-user', 'password', 'Joe', 'User',
-                                                  'juser@example.com')
-        self.tmpdir = tempfile.mkdtemp()
+        self.admin = self.model('user').createUser(
+            'wt-dm-admin-user', 'password', 'Root', 'vonKlompf', 'jadmin@example.com')
+        self.user = self.model('user').createUser(
+            'wt-dm-test-user', 'password', 'Joe', 'User', 'juser@example.com')
+        self.user2 = self.model('user').createUser(
+            'wt-dm-test-user2', 'password', 'Joey', 'Black', 'jblack@example.com')
+        self.tmpdir = {}
         self.assetstore = list(self.model('assetstore').find({}))[0]
 
         [self.testCollection, self.testFolder, self.files, self.gfiles] = \
@@ -43,7 +48,13 @@ class IntegrationTestCase(base.TestCase):
 
         self.transferredFiles = set()
 
+    def tearDown(self):
+        for prefix in self.tmpdir:
+            shutil.rmtree(self.tmpdir[prefix])
+        base.TestCase.tearDown(self)
+
     def createStructure(self, prefix):
+        self.tmpdir[prefix] = tempfile.mkdtemp()
         collection = \
             self.model('collection').createCollection('%s_wt_dm_test_col' % prefix,
                                                       creator=self.user, public=False,
@@ -51,10 +62,10 @@ class IntegrationTestCase(base.TestCase):
         folder = \
             self.model('folder').createFolder(collection, '%s_wt_dm_test_fldr' % prefix,
                                               parentType='collection')
-        files = [self.createFile('%s_%s' % (prefix, n), 1 * MB, self.tmpdir)
+        files = [self.createFile('%s_%s' % (prefix, n), 1 * MB, self.tmpdir[prefix])
                  for n in range(1, 5)]
         self.model('assetstore').importData(self.assetstore, folder, 'folder',
-                                            {'importPath': self.tmpdir}, {}, self.user,
+                                            {'importPath': self.tmpdir[prefix]}, {}, self.user,
                                             leafFoldersAsItems=False)
         gfiles = [self.model('item').findOne({'name': file}) for file in files]
 
@@ -79,9 +90,6 @@ class IntegrationTestCase(base.TestCase):
             for i in range(size):
                 f.write(b'\0')
         return name
-
-    def tearDown(self):
-        base.TestCase.tearDown(self)
 
     def makeDataSet(self, items, objectids=True):
         if objectids:
@@ -123,7 +131,89 @@ class IntegrationTestCase(base.TestCase):
         sessions = list(self.model('session', 'wt_data_manager').list(self.user))
         self.assertEqual(len(sessions), 1)
         self._testItemWithSession(session, item)
-        self.apiroot.dm.deleteSession(self.user, session=session)
+        resp = self.request(
+            path='/dm/session/{_id}/object'.format(**session),
+            method='GET', user=self.user,
+            params={'path': '/non_existent_path'}
+        )
+        self.assertStatus(resp, 400)
+
+        resp = self.request(
+            path='/dm/session/{_id}/object'.format(**session),
+            method='GET', user=self.user,
+            params={'path': '/filetest__4'}
+        )
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json['object']['_id'], str(self.gfiles[3]['_id']))
+
+        dataSet.append({
+            'itemId': str(self.testFolder2['_id']),
+            'mountPath': '/' + self.testFolder2['name']
+        })
+        dataSet = [{'itemId': str(_['itemId']), 'mountPath': _['mountPath']}
+                   for _ in dataSet]
+        resp = self.request(
+            path='/dm/session/{_id}'.format(**session),
+            method='PUT', user=self.user,
+            params={'dataSet': json.dumps(dataSet)}
+        )
+        self.assertStatusOk(resp)
+        session = resp.json
+        self.assertEqual(session['seq'], 1)
+
+        resp = self.request(
+            path='/dm/session/{_id}/object'.format(**session),
+            method='GET', user=self.user,
+            params={'path': '/' + self.testFolder2['name'], 'children': True}
+        )
+        self.assertStatusOk(resp)
+        children = resp.json['children']
+        leafFile = next((_ for _ in children if _['name'] == self.gfiles2[-1]['name']), None)
+        self.assertEqual(leafFile['_id'], str(self.gfiles2[-1]['_id']))
+
+        resp = self.request(
+            path='/dm/session/{_id}/object'.format(**session),
+            method='GET', user=self.user,
+            params={'path': '/' + self.testFolder2['name'] + '/' + leafFile['name'] + '_blah',
+                    'children': True}
+        )
+        self.assertStatus(resp, 400)
+
+        resp = self.request(
+            path='/dm/session/{_id}/object'.format(**session),
+            method='GET', user=self.user,
+            params={'path': '/' + self.testFolder2['name'] + '/' + leafFile['name'],
+                    'children': True}
+        )
+        self.assertStatusOk(resp)
+
+        resp = self.request(
+            path='/dm/session/{_id}'.format(**session),
+            method='DELETE', user=self.user2)
+        self.assertStatus(resp, 403)
+
+        resp = self.request(
+            path='/dm/session/{_id}'.format(**session),
+            method='DELETE', user=self.admin)
+        self.assertStatusOk(resp)
+
+        from girder.plugins.wholetale.models.tale import Tale
+        from bson import ObjectId
+        tale = Tale().createTale({'_id': ObjectId()}, dataSet, title='blah',
+                                 creator=self.user)
+
+        resp = self.request(
+            path='/dm/session', method='POST', user=self.user,
+            params={'taleId': str(tale['_id'])}
+        )
+        self.assertStatusOk(resp)
+        session = resp.json
+        self.assertEqual(session['dataSet'], dataSet)
+        Tale().remove(tale)  # TODO: This should fail, since the session is up
+        resp = self.request(
+            path='/dm/session/{_id}'.format(**session),
+            method='DELETE', user=self.user)
+        self.assertStatusOk(resp)
 
     def _testItem(self, dataSet, item, download=False):
         session = self.model('session', 'wt_data_manager').createSession(self.user, dataSet=dataSet)

--- a/server/models/session.py
+++ b/server/models/session.py
@@ -61,7 +61,7 @@ class Session(AccessControlledModel):
         }
 
         if tale:
-            session['dataSet'] = tale['involatileData']
+            session['dataSet'] = tale['dataSet']
             session['taleId'] = tale['_id']
         else:
             session['dataSet'] = dataSet

--- a/server/models/session.py
+++ b/server/models/session.py
@@ -175,7 +175,7 @@ class Session(AccessControlledModel):
     def getObject(self, user, session, path, children):
         self.checkOwnership(user, session)
 
-        (tail, rootContainer) = self.findRootContainer(session, path)
+        (tail, rootContainer) = self.findRootContainer(session, path, user)
         crtObj = rootContainer
 
         if tail is not None:
@@ -193,26 +193,26 @@ class Session(AccessControlledModel):
                 'object': crtObj
             }
 
-    def findRootContainer(self, session, path):
+    def findRootContainer(self, session, path, user=None):
         for obj in session['dataSet']:
             rootPath = obj['mountPath']
             if path == rootPath:
-                return (None, self.loadObject(str(obj['itemId'])))
+                return (None, self.loadObject(str(obj['itemId']), user=user))
             if rootPath[-1] != '/':
                 # add a slash at the end to avoid situations like
                 # rootPath=/name being matched for path=/nameAndStuff/...
                 rootPath = rootPath + '/'
             if path.startswith(rootPath):
-                return (path[len(rootPath):], self.loadObject(str(obj['itemId'])))
+                return (path[len(rootPath):], self.loadObject(str(obj['itemId']), user=user))
         raise LookupError('No such object: ' + path)
 
-    def loadObject(self, id):
-        item = self.folderModel.load(id, level=AccessType.READ)
+    def loadObject(self, id, user=None):
+        item = self.folderModel.load(id, level=AccessType.READ, user=user)
         if item is not None:
             item['type'] = 'folder'
             return item
         else:
-            item = self.itemModel.load(id, level=AccessType.READ)
+            item = self.itemModel.load(id, level=AccessType.READ, user=user)
             if item is not None:
                 item['type'] = 'file'
                 return item

--- a/server/models/session.py
+++ b/server/models/session.py
@@ -96,8 +96,8 @@ class Session(AccessControlledModel):
             },
             multi=False)
         session = self.load(session['_id'], user=user)
-
         events.trigger('dm.sessionModified', info=session)
+        return session
 
     def loadObjects(self, dataSet):
         for entry in dataSet:

--- a/server/resources/fs.py
+++ b/server/resources/fs.py
@@ -20,7 +20,7 @@ class FS(Resource):
         Description('Returns an unfiltered item')
         .param('itemId', 'The ID of the item.', paramType='path')
         .errorResponse('ID was invalid.')
-        .errorResponse('Object was not found.', 401)
+        .errorResponse('Object was not found.', 400)
     )
     def getItemUnfiltered(self, itemId, params):
         user = self.getCurrentUser()
@@ -32,7 +32,7 @@ class FS(Resource):
         Description('Returns an unfiltered object')
         .param('itemId', 'The ID of the object.', paramType='path')
         .errorResponse('ID was invalid.')
-        .errorResponse('Object was not found.', 401)
+        .errorResponse('Object was not found.', 400)
     )
     def getRawObject(self, id, params):
         user = self.getCurrentUser()

--- a/server/resources/session.py
+++ b/server/resources/session.py
@@ -103,11 +103,11 @@ class Session(Resource):
                default=False)
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the session.', 403)
-        .errorResponse('Object was not found.', 401)
+        .errorResponse('Object was not found.', 400)
     )
     def getObject(self, session, path, children):
         user = self.getCurrentUser()
         try:
             return SessionModel().getObject(user, session, path, children)
         except LookupError as ex:
-            raise RestException(str(ex), code=401)
+            raise RestException(str(ex), code=400)

--- a/server/resources/session.py
+++ b/server/resources/session.py
@@ -62,11 +62,16 @@ class Session(Resource):
         .jsonParam(
             'dataSet', 'An optional data set to initialize the session with. '
             'A data set is a list of objects of the form '
-            '{"itemId": string, "mountPath": string}.', paramType='query', schema=dataSetSchema)
+            '{"itemId": string, "mountPath": string}.', paramType='query', schema=dataSetSchema,
+            required=False)
+        .modelParam('taleId', "An optional id of a Tale. If provided, Tale's involatileData will "
+                    "be used to initialize the session instead of the dataSet parameter.",
+                    model='tale', plugin='wholetale', level=AccessType.READ, paramType='query',
+                    required=False)
     )
-    def createSession(self, dataSet):
+    def createSession(self, dataSet, tale):
         user = self.getCurrentUser()
-        return SessionModel().createSession(user, dataSet)
+        return SessionModel().createSession(user, dataSet=dataSet, tale=tale)
 
     @access.user
     @autoDescribeRoute(

--- a/web_client/views/ConfigView.js
+++ b/web_client/views/ConfigView.js
@@ -43,7 +43,7 @@ var ConfigView = View.extend({
         'dm.private_storage_capacity',
         'dm.gc_run_interval',
         'dm.gc_collect_start_fraction',
-        'dm.gc_collect_end_fraction',
+        'dm.gc_collect_end_fraction'
     ],
 
     settingControlId: function (key) {


### PR DESCRIPTION
This PR modifies `POST /session` to accept `taleId`. If it's provided Tale's `involatileData` is used as an initial `dataSet` for the session.

Depends on https://github.com/whole-tale/girder_wholetale/issues/213

### How to test?
Note: Assumption is you've merged https://github.com/whole-tale/girder_wholetale/issues/213 locally
1. Create a Tale with a couple folders or files as external data
2. Use `POST /session` with taleId from 1.
3. Confirm that `dataSet` in newly created session matches `involatileData` from the Tale.