### PR TITLE
Inject auth headers into UrlTransferHandler requests

### DIFF
--- a/server/lib/handlers/common.py
+++ b/server/lib/handlers/common.py
@@ -1,12 +1,28 @@
 from ..tm_utils import TransferHandler
 import os
 
+from girder.plugins.wholetale.lib import Verificators
+
 
 class UrlTransferHandler(TransferHandler):
+    _headers = None
+
     def __init__(self, url, transferId, itemId, psPath, user, transferManager):
         TransferHandler.__init__(self, transferId, itemId, psPath, user, transferManager)
         self.url = url
         self.flen = self._getFileFromItem()['size']
+
+        try:
+            verificator = Verificators[self.item["meta"]["provider"].lower()]
+            self._headers = verificator(user=user, url=url).headers
+        except KeyError:
+            pass
+
+    @property
+    def headers(self):
+        if self._headers:
+            return self._headers
+        return {}
 
     def mkdirs(self):
         try:

--- a/server/lib/handlers/http.py
+++ b/server/lib/handlers/http.py
@@ -8,4 +8,6 @@ class Http(FileLikeUrlTransferHandler):
                                             transferManager)
 
     def openInputStream(self):
-        return requests.get(self.url, stream=True, headers=self.headers).raw
+        resp = requests.get(self.url, stream=True, headers=self.headers)
+        resp.raise_for_status()  # Throw an exception in case transfer failed
+        return resp.raw

--- a/server/lib/handlers/http.py
+++ b/server/lib/handlers/http.py
@@ -8,4 +8,4 @@ class Http(FileLikeUrlTransferHandler):
                                             transferManager)
 
     def openInputStream(self):
-        return requests.get(self.url, stream=True).raw
+        return requests.get(self.url, stream=True, headers=self.headers).raw


### PR DESCRIPTION
Pass auth headers to UrlTransfers.

### How to test?
1. Follow the steps from https://github.com/whole-tale/girder_wholetale/pull/465
2. Launch a Tale
3. Confirm that registered datafiles are accessible inside the container. Example:
   * without this PR:
     ```
      $ head -n1 data/embassies.txt
      {"status":"ERROR","code":403,"message":"Not authorized to access this object via this API endpoint. Please check your codefor typos, or consult our API guide at http://guides.dataverse.org.","requestUrl":"https://demo.dataverse.org/api/v1/access/datafile/1833778","requestMethod":"GET"}
      ```
   * with this PR:
     ```
     $ head -n1 data/embassies.txt
     ABD, Abu Dhabi, United Arab Emirates
     ```