### PR TITLE
Properly handle data streams with Content-Encoding

### DIFF
--- a/server/lib/handlers/http.py
+++ b/server/lib/handlers/http.py
@@ -1,8 +1,10 @@
+import functools
 import urllib
 import zipfile
 
 import httpio
 import requests
+
 from .common import FileLikeUrlTransferHandler
 
 
@@ -21,5 +23,7 @@ class Http(FileLikeUrlTransferHandler):
                 return zipfile.Path(zf, path).open()
         else:
             resp = requests.get(self.url, stream=True, headers=self.headers)
+            if resp.headers.get("Content-Encoding") in ("gzip",):
+                resp.raw.read = functools.partial(resp.raw.read, decode_content=True)
             resp.raise_for_status()  # Throw an exception in case transfer failed
             return resp.raw


### PR DESCRIPTION
Some providers (e.g. Zenodo) send content gzipped by default. Currently we're are not handling it, and DMS caches gzipped data. This PR fixes this.

### How to test?
1. Create a Tale
2. Register [doi:10.5281/zenodo.16384](https://doi.org/10.5281/zenodo.16384), add any of the file to Tale's external data
3. Run a Tale and try to access the file.