### PR TITLE
Verify checksum of transferred files

### DIFF
--- a/server/lib/tm_utils.py
+++ b/server/lib/tm_utils.py
@@ -70,7 +70,7 @@ class TransferHandler:
 
 class TransferException(Exception):
     def __init__(self, message=None, cause=None, fatal=True):
-        super().__init__()
+        super().__init__(message)
         self.message = message
         self.cause = cause
         self.fatal = fatal


### PR DESCRIPTION
Since we now have digests for external data let's use them!

### How to test?
1. Create a Tale, register a dataset (e.g. [doi:10.18126/M2301J](http://dx.doi.org/doi:10.18126/M2301J)), add some files to external data.
2. (as girder admin) Navigate to `WholeTale Catalog/WholeTale Catalog/<your ds>/`, find the files that you've added in 1. and manually modify their checksum (store original value).
3. Run the Tale and run `cat ../data/<your_file>`.
4. You should see Input/Error in the container, and `TransferException` in girder logs.
5. (as girder admin) Revert your change to `checksum`
6. Repeat 3. It should finish successfully.