### PR TITLE
Allow to tie a session to a tale even if dataset was provided

### DIFF
--- a/server/models/session.py
+++ b/server/models/session.py
@@ -52,8 +52,8 @@ class Session(AccessControlledModel):
         :param dataSet: The initial dataSet associated with this session. The dataSet is a list
          of dictionaries with two keys: 'itemId', and 'mountPath'
         :type dataSet: list
-        :param tale: If a tale is provided, use dataSet associated with it to initialize
-         a session.
+        :param tale: If a tale is provided, tie the session to the tale. This is used to
+         automatically refresh the dataSet when the tale is updated.
         :type tale: dict or None
         """
 
@@ -64,11 +64,9 @@ class Session(AccessControlledModel):
         }
 
         if tale:
-            session['dataSet'] = tale['dataSet']
             session['taleId'] = tale['_id']
-        else:
-            session['dataSet'] = dataSet
 
+        session["dataSet"] = dataSet or tale.get("dataSet", [])
         session = self.setUserAccess(session, user=user, level=AccessType.ADMIN, save=True)
         # TODO: is the custom event really necessary? save in here ^^ already triggers
         #  'model.session.save', with info=session

--- a/server/resources/session.py
+++ b/server/resources/session.py
@@ -64,8 +64,9 @@ class Session(Resource):
             'A data set is a list of objects of the form '
             '{"itemId": string, "mountPath": string}.', paramType='query', schema=dataSetSchema,
             required=False)
-        .modelParam('taleId', "An optional id of a Tale. If provided, Tale's involatileData will "
-                    "be used to initialize the session instead of the dataSet parameter.",
+        .modelParam("taleId", "An optional id of a Tale. If provided, a Tale will be tied to this "
+                    "session and any update on the Tale's dataSet "
+                    "will be reflected in the session.",
                     model='tale', plugin='wholetale', level=AccessType.READ, paramType='query',
                     required=False)
     )


### PR DESCRIPTION
We are no longer initializing `dataSet` by just passing Tale object to dms. However, we still need to track if a session belongs to a particular Tale.

Fixes the issue when local girderfs mounts were not updating after Tale object was modified.

### How to test?
1. Deploy this and use girderfs image from ...
2. Create a Tale and run it.
3. Confirm `ls ../data` returns nothing
4. Register a dataset, add it to external data in a running tale
5. Confirm `ls ../data` returns new files.